### PR TITLE
Update webpack helper to be compliant with Girder 2.3.0 client build

### DIFF
--- a/webpack.helper.js
+++ b/webpack.helper.js
@@ -1,18 +1,26 @@
 module.exports = function (config) {
-    config.module.loaders.push({
-        test: /\.glsl$/,
-        loader: 'shader-loader',
-        include: [/node_modules(\/|\\)vtk\.js(\/|\\)/],
+    config.module.rules.push({
+        resource: {
+            test: /node_modules(\/|\\)vtk\.js(\/|\\).*.glsl$/,
+            include: [/node_modules(\/|\\)vtk\.js(\/|\\)/]
+        },
+        use: [
+            'shader-loader'
+        ]
     });
-    config.module.loaders.push({
-        test: /\.js$/,
-        include: [/node_modules(\/|\\)vtk\.js(\/|\\)/],
-        loaders: [{
-            loader: 'babel-loader',
-            query: {
-                presets: ['es2015']
+    config.module.rules.push({
+        resource: {
+            test: /node_modules(\/|\\)vtk\.js(\/|\\).*.js$/,
+            include: [/node_modules(\/|\\)vtk\.js(\/|\\)/]
+        },
+        use: [
+            {
+                loader: 'babel-loader',
+                options: {
+                    presets: ['es2015', 'es2016']
+                }
             }
-        }]
+        ]
     });
     return config;
 };


### PR DESCRIPTION
Fixes #1.

@zachmullen 